### PR TITLE
Fix footer link in templates/index.html

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -52,7 +52,7 @@
         <footer>
             <p>
                 © {{ config.title }} {{ now() | date(format="%Y") }}<br>
-                Powered by <a target="_blank" href="https://getzola.com/">Zola</a>, Theme <a target="_blank" href="https://github.com/zbrox/anpu">Anpu</a>.
+                Powered by <a target="_blank" href="https://getzola.com/">Zola</a>, Theme <a target="_blank" href="https://github.com/zbrox/anpu-zola-theme">Anpu</a>.
             </p>
             <p>
                 {% block footer %}


### PR DESCRIPTION
Github 404s instead of redirecting with the previous link.

Also, add newline at end of file as required by posix standard.