### PR TITLE
Change README theme instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ git clone https://github.com/zbrox/anpu-zola-theme.git themes/anpu
 Then set your theme setting in `config.toml` to `anpu`:
 
 ```toml
-theme = "anpu-zola-theme"
+theme = "anpu"
 ```
 
 This theme requires both the `tags` and `categories` taxonomies.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is a port of the Hugo theme [Anubis](https://github.com/Mitrichius/hugo-the
 In order to use the theme you need to clone this repository in your `themes` folder and set your theme setting in `config.toml` to `anpu`. Like this
 
 ```toml
-theme = "anpu"
+theme = "anpu-zola-theme"
 ```
 
 This theme requires both the `tags` and `categories` taxonomies.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,13 @@ This is a port of the Hugo theme [Anubis](https://github.com/Mitrichius/hugo-the
 
 ## Usage
 
-In order to use the theme you need to clone this repository in your `themes` folder and set your theme setting in `config.toml` to `anpu`. Like this
+In order to use the theme you need to clone this repository in your `themes` folder:
+
+```bash
+git clone https://github.com/zbrox/anpu-zola-theme.git themes/anpu
+```
+
+Then set your theme setting in `config.toml` to `anpu`:
 
 ```toml
 theme = "anpu"


### PR DESCRIPTION
If you do a git clone as the instructions point out, the directory should be named in themes as `anpu-zola-theme` not `anpu`. Otherwise zola will complain with 

```
No `theme.toml` file found. Is the `theme` defined in your `config.toml` present in the `themes` directory and does it have a `theme.toml` inside?`
```