### PR TITLE
Improve Font Loading

### DIFF
--- a/sass/main.scss
+++ b/sass/main.scss
@@ -1,5 +1,9 @@
 /* Basic */
-@import url('https://fonts.googleapis.com/css?family=Montserrat&display=swap');
+@font-face {
+    font-family: 'Montserrat';
+    src: local("Montserrat"), url("https://fonts.googleapis.com/css?family=Montserrat&display=swap");
+}
+
 html {
     font-family: -apple-system, BlinkMacSystemFont, 'Montserrat', 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
     /* 1 */

--- a/sass/main.scss
+++ b/sass/main.scss
@@ -1,7 +1,8 @@
 /* Basic */
 @font-face {
     font-family: 'Montserrat';
-    src: local("Montserrat"), url("https://fonts.googleapis.com/css?family=Montserrat&display=swap");
+    src: local("Montserrat"), url("https://fonts.gstatic.com/s/montserrat/v25/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCtr6Hw5aXo.woff2");
+    font-display: swap;
 }
 
 html {


### PR DESCRIPTION
This improves load for fonts by using the locally installed font if it exists, it also avoids the use of "@import" which yellowlabtools flags:

![2023-03-19_17-02-22](https://user-images.githubusercontent.com/106644/226218646-c47a80a8-2833-47d7-a96d-969b15856eea.png)
