### PR TITLE
feat: use `<time>` tag for datetime

### DIFF
--- a/templates/macros/page.html
+++ b/templates/macros/page.html
@@ -1,7 +1,7 @@
 {% macro page_info(page) %}
     <div class="article-info">
         {% if page.date %}
-        <div class="article-date">{{ page.date | date(format=config.extra.anpu_date_format) }}</div>
+        <time class="article-date" datetime="{{ page.date }}">{{ page.date | date(format=config.extra.anpu_date_format) }}</time>
         {% endif %}
         <div class="article-taxonomies">
             {% if page.taxonomies.categories %}


### PR DESCRIPTION
| no style changes | with custom `<time>` formatter applied |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/4f811e37-9eff-4dbe-80df-1294767011a8) | ![image](https://github.com/user-attachments/assets/0b2c6c6e-2493-433c-aeb6-596d9f64a5f8) |


resolves #14