### PR TITLE
Fix codeblock dark theme

### DIFF
--- a/sass/_theme.scss
+++ b/sass/_theme.scss
@@ -83,6 +83,10 @@ $accent-dark: #959bf0;
     background-color: $tertiary-dark;
   }
 
+  pre {
+    background-color: $tertiary-dark; 
+  }
+  
   pre code {
     background-color: transparent;
   }


### PR DESCRIPTION
Pre fix
<img width="788" height="150" alt="image" src="https://github.com/user-attachments/assets/18ac228c-3ecd-476a-979c-2ede03f3e543" />
<img width="629" height="134" alt="image" src="https://github.com/user-attachments/assets/659fb713-1401-4eca-8854-fa96bb92d61f" />

Post fix
<img width="772" height="140" alt="image" src="https://github.com/user-attachments/assets/8e5eb508-fb13-492f-851b-d3d3fba51ab3" />

This commit fixes the background on codeblocks using the dark theme. The issue seems to have been the `pre` tag always using the light theme, then the `pre code` being transparent (which is correct) caused the text to be the same colour as the background. 

Hope this is all okay. 
